### PR TITLE
Fix bad export

### DIFF
--- a/RNGoogleAPIAvailability.js
+++ b/RNGoogleAPIAvailability.js
@@ -1,7 +1,6 @@
 'use strict';
 
 var ReactNative = require('react-native')
-var Platform = ReactNative.Platform
 var GoogleAPIAvailability = ReactNative.NativeModules.ReactNativeGooglePlayServices;
 
 class RNGoogleAPIAvailability {
@@ -22,4 +21,4 @@ class RNGoogleAPIAvailability {
 	}
 }
 
-module.exports = new ReactNativeGoogleAPIAvailabilityBridge();
+module.exports = new RNGoogleAPIAvailability();


### PR DESCRIPTION
Hi, we need a bridge to the google play store API and this lib seems to be the trick.However after yarn install we got this error and were unable to continue

<img width="1242" alt="Screenshot 2023-01-13 at 12 36 19 PM" src="https://user-images.githubusercontent.com/35927471/212393829-418dbeec-974a-4b01-92e8-07f533f00bf6.png">

We've forked the repo for now to unblock and fix the (what we think) the wrong export